### PR TITLE
[HEDG-1950] Upgrade to OpenSearch 1.3 Goal

### DIFF
--- a/opensearch-rails/lib/opensearch/rails/tasks/import.rb
+++ b/opensearch-rails/lib/opensearch/rails/tasks/import.rb
@@ -77,11 +77,12 @@ namespace :opensearch do
         rescue NoMethodError; end
       end
 
-      total_errors = klass.__opensearch__.import force:      ENV.fetch('FORCE', false),
-                                  batch_size: ENV.fetch('BATCH', 1000).to_i,
-                                  index:      ENV.fetch('INDEX', nil),
-                                  type:       ENV.fetch('TYPE',  nil),
-                                  scope:      ENV.fetch('SCOPE', nil) do |response|
+      total_errors = klass.__opensearch__.import(
+        force:      ENV.fetch('FORCE', false),
+        batch_size: ENV.fetch('BATCH', 100).to_i,
+        index:      ENV.fetch('INDEX', nil),
+        scope:      ENV.fetch('SCOPE', nil),
+      ) do |response|
         pbar.inc response['items'].size if pbar
         STDERR.flush
         STDOUT.flush


### PR DESCRIPTION
https://hedgeyedev.atlassian.net/browse/HEDG-1950

- type is not a valid import option, so it sticks around for the underlying ActiveRecord query, which raises an error
- default the batch size to 100